### PR TITLE
平均点と最高点の表示

### DIFF
--- a/components/atoms/JirikiRank.vue
+++ b/components/atoms/JirikiRank.vue
@@ -1,6 +1,6 @@
 <template>
-  <td :class="classObj">
-    {{ jirikiRank }}
+  <td align="center">
+    <span class="tag is-medium" :class="classObj">{{ jirikiRank }}</span>
   </td>
 </template>
 
@@ -129,60 +129,60 @@ export default Vue.extend({
 
 <style>
 .red {
-  color: crimson;
+  color: crimson !important;
 }
 
 .white {
-  color: white;
+  color: white !important;
 }
 
 .splus {
-  background-color: black;
-  font-weight: bold;
+  background-color: black !important;
+  font-weight: bold !important;
 }
 
 .sn {
-  background-color: black;
-  font-weight: bold;
+  background-color: black !important;
+  font-weight: bold !important;
 }
 
 .aplus {
-  background-color: #333333;
+  background-color: #333333 !important;
 }
 
 .an {
-  background-color: #3f3f3f;
+  background-color: #3f3f3f !important;
 }
 
 .bplus {
-  background-color: #5f5f5f;
+  background-color: #5f5f5f !important;
 }
 
 .bn {
-  background-color: #7f7f7f;
+  background-color: #7f7f7f !important;
 }
 
 .cn {
-  background-color: #9f9f9f;
+  background-color: #9f9f9f !important;
 }
 
 .dn {
-  background-color: #bfbfbf;
+  background-color: #bfbfbf !important;
 }
 
 .en {
-  background-color: #efefef;
+  background-color: #efefef !important;
 }
 
 .fn {
-  background-color: #cfdfe6;
+  background-color: #cfdfe6 !important;
 }
 
 .unaccomplished {
-  background-color: orange;
+  background-color: orange !important;
 }
 
 .default-jiriki {
-  background-color: white;
+  background-color: white !important;
 }
 </style>

--- a/components/atoms/ScoreDetailStyle.vue
+++ b/components/atoms/ScoreDetailStyle.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <div style="white-space: nowrap;">
+      <span class="tag color-gold">BEST:&nbsp;{{ max }}</span>
+      <font-awesome-icon
+        v-if="score >= max"
+        :icon="['fa', 'medal']"
+      ></font-awesome-icon>
+    </div>
+    <div style="white-space: nowrap;">
+      <span class="tag color-silver">AVG&nbsp;:&nbsp;{{ average }}</span>
+      <font-awesome-icon
+        v-if="score >= average"
+        :icon="['fa', 'medal']"
+      ></font-awesome-icon>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { faMedal } from '@fortawesome/free-solid-svg-icons'
+
+library.add(faMedal)
+
+export default Vue.extend({
+  name: 'ScoreDetailStyle',
+  components: { FontAwesomeIcon },
+  props: {
+    score: {
+      type: Number,
+      default: 0
+    },
+    max: {
+      type: Number,
+      default: 0
+    },
+    average: {
+      type: Number,
+      default: 0
+    }
+  }
+})
+</script>
+
+<style>
+.color-gold {
+  color: #dbb400;
+}
+.color-silver {
+  color: #c9caca;
+}
+</style>

--- a/components/atoms/ScoreStyle.vue
+++ b/components/atoms/ScoreStyle.vue
@@ -1,14 +1,16 @@
 <template>
-  <td :class="classObject" align="right">
-    <span v-if="edit" class="control">
-      <score-form
-        :score="score"
-        :song-id="songId"
-        :user-id="playerId"
-        @score-submitted="scoreSubmitted"
-      />
-    </span>
-    <span v-else>{{ scoreView }}</span>
+  <td align="center">
+    <div class="tag is-large" :class="classObject">
+      <span v-if="edit" class="control">
+        <score-form
+          :score="score"
+          :song-id="songId"
+          :user-id="playerId"
+          @score-submitted="scoreSubmitted"
+        />
+      </span>
+      <span v-else>{{ scoreView }}</span>
+    </div>
   </td>
 </template>
 
@@ -97,22 +99,25 @@ export default Vue.extend({
 
 <style>
 .masakaHonkija {
-  background-color: #efefef;
+  background-color: #efefef !important;
 }
 
 .chutoHampa {
-  background-color: #a4c2ea;
+  background-color: #a4c2ea !important;
 }
 
 .masakaKonoteido {
-  background-color: #ea9999;
+  background-color: #ea9999 !important;
 }
 
 .manzokuSitenai {
-  background-color: #cccccc;
+  background-color: #cccccc !important;
 }
 
 .chousiniNorunja {
-  background-color: gold;
+  background-color: gold !important;
+}
+.text-muted {
+  color: #6c757d !important;
 }
 </style>

--- a/components/molecules/SongColWithScore.vue
+++ b/components/molecules/SongColWithScore.vue
@@ -14,22 +14,11 @@
       {{ song.instrument }}
     </td>
     <td>
-      <div style="white-space: nowrap;">
-        <span class="tag">BEST:&nbsp;{{ song.max }}</span>
-        <font-awesome-icon
-          v-if="song.score >= song.max"
-          :icon="['fa', 'medal']"
-          color="#DBB400"
-        ></font-awesome-icon>
-      </div>
-      <div style="white-space: nowrap;">
-        <span class="tag">AVG&nbsp;:&nbsp;{{ song.average }}</span>
-        <font-awesome-icon
-          v-if="song.score >= song.average"
-          :icon="['fa', 'medal']"
-          color="#C9CACA"
-        ></font-awesome-icon>
-      </div>
+      <ScoreDetailStyle
+        :score="song.score"
+        :max="song.max"
+        :average="song.average"
+      ></ScoreDetailStyle>
     </td>
     <ScoreStyle
       :id="'score_' + song.songId"
@@ -48,15 +37,11 @@ import Vue from 'vue'
 import SongsWithScore from '../types/SongsWithScore'
 import JirikiRank from '../atoms/JirikiRank.vue'
 import ScoreStyle from '../atoms/ScoreStyle.vue'
-import { library } from '@fortawesome/fontawesome-svg-core'
-import { faMedal } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-
-library.add(faMedal)
+import ScoreDetailStyle from '../atoms/ScoreDetailStyle.vue'
 
 export default Vue.extend({
   name: 'SongColWithScore',
-  components: { FontAwesomeIcon, JirikiRank, ScoreStyle },
+  components: { JirikiRank, ScoreStyle, ScoreDetailStyle },
   props: {
     song: {
       type: SongsWithScore,

--- a/components/molecules/SongColWithScore.vue
+++ b/components/molecules/SongColWithScore.vue
@@ -16,6 +16,20 @@
     </td>
     <ScoreStyle
       :id="'score_' + song.songId"
+      :score="song.max"
+      :song-id="song.songId"
+      :player-id="playerId"
+      :decimal="isDecimal"
+    ></ScoreStyle>
+    <ScoreStyle
+      :id="'score_' + song.songId"
+      :score="song.average"
+      :song-id="song.songId"
+      :player-id="playerId"
+      :decimal="isDecimal"
+    ></ScoreStyle>
+    <ScoreStyle
+      :id="'score_' + song.songId"
       :score="song.score"
       :song-id="song.songId"
       :player-id="playerId"
@@ -35,7 +49,7 @@ export default Vue.extend({
   props: {
     song: {
       type: SongsWithScore,
-      default: new SongsWithScore('', '', '', '', '', 0)
+      default: new SongsWithScore('', '', '', '', '', 0, 0, 0)
     },
     decimal: {
       type: Boolean,

--- a/components/molecules/SongColWithScore.vue
+++ b/components/molecules/SongColWithScore.vue
@@ -1,5 +1,5 @@
 <template>
-  <tr>
+  <tr class="score-table-tr">
     <JirikiRank
       :id="'jiriki_' + song.songId"
       :jiriki-rank="song.jirikiRank"
@@ -7,30 +7,35 @@
     ></JirikiRank>
     <td :id="'songname_' + song.songId" @click="jumpToInfoPage">
       {{ song.songName }}
-    </td>
-    <td :id="'contributor_' + song.songId" @click="jumpToInfoPage">
-      {{ song.contributor }}
+      <br class="is-hidden-desktop" />
+      <span class="text-muted">/&nbsp;{{ song.contributor }} </span>
     </td>
     <td :id="'instrument_' + song.songId" @click="jumpToInfoPage">
       {{ song.instrument }}
     </td>
-    <ScoreStyle
-      :id="'score_' + song.songId"
-      :score="song.max"
-      :song-id="song.songId"
-      :player-id="playerId"
-      :decimal="isDecimal"
-    ></ScoreStyle>
-    <ScoreStyle
-      :id="'score_' + song.songId"
-      :score="song.average"
-      :song-id="song.songId"
-      :player-id="playerId"
-      :decimal="isDecimal"
-    ></ScoreStyle>
+    <td>
+      <div style="white-space: nowrap;">
+        <span class="tag">BEST:&nbsp;{{ song.max }}</span>
+        <font-awesome-icon
+          v-if="song.score >= song.max"
+          :icon="['fa', 'medal']"
+          color="#DBB400"
+        ></font-awesome-icon>
+      </div>
+      <div style="white-space: nowrap;">
+        <span class="tag">AVG&nbsp;:&nbsp;{{ song.average }}</span>
+        <font-awesome-icon
+          v-if="song.score >= song.average"
+          :icon="['fa', 'medal']"
+          color="#C9CACA"
+        ></font-awesome-icon>
+      </div>
+    </td>
     <ScoreStyle
       :id="'score_' + song.songId"
       :score="song.score"
+      :max="song.max"
+      :average="song.average"
       :song-id="song.songId"
       :player-id="playerId"
       :decimal="isDecimal"
@@ -43,9 +48,15 @@ import Vue from 'vue'
 import SongsWithScore from '../types/SongsWithScore'
 import JirikiRank from '../atoms/JirikiRank.vue'
 import ScoreStyle from '../atoms/ScoreStyle.vue'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faMedal } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+
+library.add(faMedal)
+
 export default Vue.extend({
   name: 'SongColWithScore',
-  components: { JirikiRank, ScoreStyle },
+  components: { FontAwesomeIcon, JirikiRank, ScoreStyle },
   props: {
     song: {
       type: SongsWithScore,
@@ -72,3 +83,12 @@ export default Vue.extend({
   }
 })
 </script>
+<style scoped>
+.score-table-tr td {
+  vertical-align: middle !important;
+}
+.text-muted {
+  font-size: 0.8em;
+  color: #6c757d !important;
+}
+</style>

--- a/components/molecules/__test__/SongColWithScore.test.ts
+++ b/components/molecules/__test__/SongColWithScore.test.ts
@@ -10,7 +10,9 @@ describe(SongColWithScore.default, () => {
     'あれ',
     'それ',
     'シンセリード',
-    76
+    76,
+    80,
+    99
   )
 
   const wrapper = shallowMount(SongColWithScore.default, {

--- a/components/organisms/SongsTable.vue
+++ b/components/organisms/SongsTable.vue
@@ -68,7 +68,7 @@ export default Vue.extend({
     },
     async loadMore(query: string) {
       let numberOfSongsAdded: number = await axios
-        .get(process.env.apiBaseUrl + '/v1' + query)
+        .get(process.env.apiBaseUrl + '/v2' + query)
         .then(response => {
           if (response.data.length > 0) {
             response.data.forEach(element => {

--- a/components/organisms/SongsTableWithScore.vue
+++ b/components/organisms/SongsTableWithScore.vue
@@ -5,6 +5,8 @@
       <th>楽曲名</th>
       <th>投稿者名</th>
       <th>楽器名</th>
+      <th>最高点</th>
+      <th>平均点</th>
       <th>得点</th>
     </thead>
     <tbody>
@@ -57,7 +59,7 @@ export default Vue.extend({
       const apiBaseUrl: string =
         process.env.apiBaseUrl || 'http://localhost:8080'
       await axios
-        .get(apiBaseUrl + '/v1' + query)
+        .get(apiBaseUrl + '/v2' + query)
         .then(response => {
           this.songs = response.data.map(s => {
             return new SongsWithScore(
@@ -66,7 +68,9 @@ export default Vue.extend({
               s.songName,
               s.contributor,
               s.instrument,
-              s.score
+              s.score,
+              s.average,
+              s.max
             )
           })
         })
@@ -82,7 +86,7 @@ export default Vue.extend({
       const apiBaseUrl: string =
         process.env.apiBaseUrl || 'http://localhost:8080'
       await axios
-        .get(apiBaseUrl + '/v1' + query)
+        .get(apiBaseUrl + '/v2' + query)
         .then(response => {
           response.data.forEach(s => {
             count++
@@ -93,7 +97,9 @@ export default Vue.extend({
                 s.songName,
                 s.contributor,
                 s.instrument,
-                s.score
+                s.score,
+                s.average,
+                s.max
               )
             )
           })

--- a/components/organisms/SongsTableWithScore.vue
+++ b/components/organisms/SongsTableWithScore.vue
@@ -1,13 +1,18 @@
 <template>
-  <table>
+  <table id="score-table">
     <thead>
-      <th>地力</th>
-      <th>楽曲名</th>
-      <th>投稿者名</th>
-      <th>楽器名</th>
-      <th>最高点</th>
-      <th>平均点</th>
-      <th>得点</th>
+      <th align="center">
+        地力
+      </th>
+      <th align="center">
+        楽曲名
+      </th>
+      <th align="center">
+        楽器名
+      </th>
+      <th align="center" colspan="2">
+        得点
+      </th>
     </thead>
     <tbody>
       <SongColWithScore
@@ -69,8 +74,8 @@ export default Vue.extend({
               s.contributor,
               s.instrument,
               s.score,
-              s.average,
-              s.max
+              s.max,
+              s.average
             )
           })
         })
@@ -98,8 +103,8 @@ export default Vue.extend({
                 s.contributor,
                 s.instrument,
                 s.score,
-                s.average,
-                s.max
+                s.max,
+                s.average
               )
             )
           })

--- a/components/types/SongsWithScore.ts
+++ b/components/types/SongsWithScore.ts
@@ -9,7 +9,9 @@ export default class SongsWithScore extends Songs {
     songName: string,
     contributor: string,
     instrument: string,
-    score: Number
+    score: Number,
+    average: Number,
+    max: Number
   ) {
     super(songId, jirikiRank, songName, contributor, instrument)
     this.score = score

--- a/components/types/SongsWithScore.ts
+++ b/components/types/SongsWithScore.ts
@@ -1,7 +1,10 @@
 import Songs from './Songs'
+import { AuthServiceStub } from '~/pages/__stubs__/AuthServiceMock'
 
 export default class SongsWithScore extends Songs {
   score: Number
+  max: Number
+  average: Number
 
   constructor(
     songId: string,
@@ -10,10 +13,12 @@ export default class SongsWithScore extends Songs {
     contributor: string,
     instrument: string,
     score: Number,
-    average: Number,
-    max: Number
+    max: Number,
+    average: Number
   ) {
     super(songId, jirikiRank, songName, contributor, instrument)
     this.score = score
+    this.max = max
+    this.average = average
   }
 }


### PR DESCRIPTION
scoreの方が大きいときにメダルも表示します。

以下、ちょっと気になっている点です。
- ログイン時の挙動がこちらでテストすることができないので確認して欲しいです
- ログインしていない状態で「プレイヤーで検索」を開いたときのプレイヤーは空欄にして得点を表示したくないのですが、フロント修正/API修正どちらで対応しても大変そうなので何か対策案を検討したいです。（今の状態だと平均が表示されているのもちょっと嫌で、平均のところにメダルもついてしまう。こちらの実装がｱﾚなんですが…）
- 詳細画面や楽曲から探すのページとプレイヤーから探すの見た目が異なる
　→そのうち私の方で対応すると思います。